### PR TITLE
Fixed directory routes

### DIFF
--- a/components/Navigation/Navigation.js
+++ b/components/Navigation/Navigation.js
@@ -17,6 +17,9 @@ function Navigation() {
       <li className="Navigation-item">
         <a className="Navigation-link" href="/about" onClick={Link.handleClick}>About</a>
       </li>
+      <li className="Navigation-item">
+        <a className="Navigation-link" href="/blog/" onClick={Link.handleClick}>Blog</a>
+      </li>
     </ul>
   );
 }

--- a/tools/lib/routes-loader.js
+++ b/tools/lib/routes-loader.js
@@ -46,7 +46,7 @@ export default function(source) {
       }
 
       if (dir) {
-        let dirpath = path + '/';
+        const dirpath = path + '/';
         subDirectories.push(`  '${dirpath}': () => new Promise(resolve => require(['./pages/${file}'], resolve)),`);
       }
 

--- a/tools/lib/routes-loader.js
+++ b/tools/lib/routes-loader.js
@@ -27,9 +27,9 @@ export default function(source) {
       if (path === '/index.js' || path === '/index.jsx') {
         path = '/';
       } else if (path.endsWith('/index.js')) {
-        path = path.substr(0, path.length - 9);
+        path = path.substr(0, path.length - 8);
       } else if (path.endsWith('/index.jsx')) {
-        path = path.substr(0, path.length - 10);
+        path = path.substr(0, path.length - 9);
       } else if (path.endsWith('.js')) {
         path = path.substr(0, path.length - 3);
       } else if (path.endsWith('.jsx')) {

--- a/tools/lib/routes-loader.js
+++ b/tools/lib/routes-loader.js
@@ -21,15 +21,20 @@ export default function(source) {
       return callback(err);
     }
 
+    const subDirectories = [];
+
     const lines = files.map(file => {
       let path = '/' + file;
+      let dir = false;
 
       if (path === '/index.js' || path === '/index.jsx') {
         path = '/';
       } else if (path.endsWith('/index.js')) {
-        path = path.substr(0, path.length - 8);
-      } else if (path.endsWith('/index.jsx')) {
+        dir = true;
         path = path.substr(0, path.length - 9);
+      } else if (path.endsWith('/index.jsx')) {
+        dir = true;
+        path = path.substr(0, path.length - 10);
       } else if (path.endsWith('.js')) {
         path = path.substr(0, path.length - 3);
       } else if (path.endsWith('.jsx')) {
@@ -40,8 +45,16 @@ export default function(source) {
         return `  '${path}': () => require('./pages/${file}'),`;
       }
 
+      if (dir) {
+        let dirpath = path + '/';
+        subDirectories.push(`  '${dirpath}': () => new Promise(resolve => require(['./pages/${file}'], resolve)),`);
+      }
+
       return `  '${path}': () => new Promise(resolve => require(['./pages/${file}'], resolve)),`;
     });
+
+    // Add the sub directories to the list of routes
+    Array.prototype.push.apply(lines, subDirectories);
 
     if (lines.length) {
       return callback(null, source.replace(' routes = {', ' routes = {\n' + lines.join('')));


### PR DESCRIPTION
Fixes #37

~/tools/lib/routes-loader.js now renders the trailing
slash at the end of directories. This fixes directory
browsing with no "filename".