### PR TITLE
Fix Link props order with spread operator

### DIFF
--- a/components/Link/Link.js
+++ b/components/Link/Link.js
@@ -53,7 +53,7 @@ class Link extends Component {
 
   render() {
     const { to, children, ...props } = this.props;
-    return <a onClick={Link.handleClick.bind(this)} {...props}>{children}</a>;
+    return <a {...props} onClick={Link.handleClick.bind(this)}>{children}</a>;
   }
 
 }


### PR DESCRIPTION
When using props in conjunction with the spread operator, values provided last override earlier ones. 

If you're using `Link` as an actual component and specified a custom `onClick` handler, `Link.handleClick` would never get executed because it's overridden by `{...props}` being last.