### PR TITLE
upgrade to support Babel 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "stage": 0
+  "presets": ["react", "es2015", "stage-0"]
 }

--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@
  * Copyright (c) Konstantin Tarkus (@koistya) | MIT license
  */
 
-import 'babel/polyfill';
+import 'babel-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
@@ -16,7 +16,7 @@ const routes = {}; // Auto-generated on build. See tools/lib/routes-loader.js
 const route = async (path, callback) => {
   const handler = routes[path] || routes['/404'];
   const component = await handler();
-  await callback(<Layout>{React.createElement(component)}</Layout>);
+  await callback(<Layout>{React.createElement(component.default)}</Layout>);
 };
 
 function run() {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
   "devDependencies": {
     "autoprefixer": "^6.0.3",
-    "babel": "^5.8.29",
-    "babel-core": "^5.8.29",
-    "babel-eslint": "^4.1.3",
-    "babel-loader": "^5.3.2",
-    "babel-plugin-react-transform": "^1.1.1",
+    "babel-cli": "^6.3.17",
+    "babel-core": "^6.3.26",
+    "babel-eslint": "^4.1.6",
+    "babel-loader": "^6.2.1",
+    "babel-plugin-react-transform": "^2.0.0",
+    "babel-polyfill": "^6.3.14",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
+    "babel-preset-stage-0": "^6.3.13",
     "browser-sync": "^2.9.11",
     "chai": "^3.4.0",
     "css-loader": "^0.21.0",
@@ -44,9 +48,9 @@
   "scripts": {
     "lint": "eslint src tools test",
     "test": "npm run lint && mocha --compilers js:babel/register",
-    "clean": "babel-node --eval \"require('./tools/clean')().catch(err => console.log(err.stack))\"",
-    "build": "babel-node --eval \"require('./tools/build')().catch(err => console.log(err.stack))\"",
-    "start": "babel-node --eval \"require('./tools/start')().catch(err => console.log(err.stack))\"",
-    "deploy": "babel-node --eval \"require('./tools/deploy')().catch(err => console.log(err.stack))\""
+    "clean": "babel-node --eval \"require('./tools/clean').default().catch(err => console.log(err.stack))\"",
+    "build": "babel-node --eval \"require('./tools/build').default().catch(err => console.log(err.stack))\"",
+    "start": "babel-node --eval \"require('./tools/start').default().catch(err => console.log(err.stack))\"",
+    "deploy": "babel-node --eval \"require('./tools/deploy').default().catch(err => console.log(err.stack))\""
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
+    "babel-register": "^6.3.13",
     "browser-sync": "^2.9.11",
     "chai": "^3.4.0",
     "css-loader": "^0.21.0",
@@ -47,7 +48,7 @@
   },
   "scripts": {
     "lint": "eslint src tools test",
-    "test": "npm run lint && mocha --compilers js:babel/register",
+    "test": "npm run lint && mocha --compilers js:babel-register",
     "clean": "babel-node --eval \"require('./tools/clean').default().catch(err => console.log(err.stack))\"",
     "build": "babel-node --eval \"require('./tools/build').default().catch(err => console.log(err.stack))\"",
     "start": "babel-node --eval \"require('./tools/start').default().catch(err => console.log(err.stack))\"",

--- a/test/routes-loader-spec.js
+++ b/test/routes-loader-spec.js
@@ -4,6 +4,7 @@
  * Copyright (c) Konstantin Tarkus (@koistya) | MIT license
  */
 
+import 'babel-polyfill';
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
@@ -15,7 +16,6 @@ describe('routes-loader', () => {
       expect(result).to.not.to.be.empty.and.have.all.keys('/', '/404', '/500');
       done();
     };
-
     require('../tools/lib/routes-loader').call(this, 'const routes = {};');
   });
 });

--- a/tools/build.js
+++ b/tools/build.js
@@ -5,10 +5,14 @@
  */
 
 import task from './lib/task';
+import clean from './clean';
+import copy from './copy';
+import bundle from './bundle';
+import render from './render';
 
 export default task(async function build() {
-  await require('./clean')();
-  await require('./copy')();
-  await require('./bundle')();
-  await require('./render')();
+  await clean();
+  await copy();
+  await bundle();
+  await render();
 });

--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -6,6 +6,7 @@
 
 import GitRepo from 'git-repository';
 import task from './lib/task';
+import build from './build';
 
 // TODO: Update deployment URL
 const remote = {
@@ -33,7 +34,7 @@ export default task(async function deploy() {
   // Build the project in RELEASE mode which
   // generates optimized and minimized bundles
   process.argv.push('release');
-  await require('./build')();
+  await build();
 
   // Push the contents of the build folder to the remote server via Git
   await repo.add('--all .');

--- a/tools/lib/routes-loader.js
+++ b/tools/lib/routes-loader.js
@@ -7,13 +7,13 @@
 import glob from 'glob';
 import { join } from 'path';
 
-export default function(source) {
+module.exports = function(source) {
   this.cacheable();
   const target = this.target;
   const callback = this.async();
 
   if (target === 'node') {
-    source = source.replace('import \'babel/polyfill\';', ''); // eslint-disable-line no-param-reassign
+    source = source.replace('import \'babel-polyfill\';', ''); // eslint-disable-line no-param-reassign
   }
 
   glob('**/*.{js,jsx}', { cwd: join(__dirname, '../../pages') }, (err, files) => {
@@ -49,4 +49,4 @@ export default function(source) {
 
     return callback(new Error('Cannot find any routes.'));
   });
-}
+};

--- a/tools/render.js
+++ b/tools/render.js
@@ -47,7 +47,7 @@ async function renderPage(page, component) {
 
 export default task(async function render() {
   const pages = await getPages();
-  const { route } = require('../build/app.node');
+  const { route } = require('../build/app.node').default;
   for (const page of pages) {
     await route(page.path, renderPage.bind(undefined, page));
   }

--- a/tools/start.js
+++ b/tools/start.js
@@ -9,13 +9,15 @@ import webpack from 'webpack';
 import hygienistMiddleware from 'hygienist-middleware';
 import webpackDevMiddleware from 'webpack-dev-middleware';
 import webpackHotMiddleware from 'webpack-hot-middleware';
+import build from './build';
+import config from './webpack.config';
 
 global.watch = true;
-const webpackConfig = require('./webpack.config')[0];
+const webpackConfig = config[0];
 const bundler = webpack(webpackConfig);
 
 export default async () => {
-  await require('./build')();
+  await build();
 
   browserSync({
     server: {


### PR DESCRIPTION
Update `Babel` to `v6.x`. 

1. Minimal changes to tools script ( several lines).
2. No change to source files.
3. All npm script execute successfully.