### PR TITLE
include jsx files

### DIFF
--- a/tools/render.js
+++ b/tools/render.js
@@ -16,7 +16,7 @@ const DEBUG = !process.argv.includes('release');
 
 function getPages() {
   return new Promise((resolve, reject) => {
-    glob('**/*.js', { cwd: join(__dirname, '../pages') }, (err, files) => {
+    glob('**/*.{js,jsx}', { cwd: join(__dirname, '../pages') }, (err, files) => {
       if (err) {
         reject(err);
       } else {


### PR DESCRIPTION
### The bug:

Without this line, static HTML files are not created for their corresponding `.jsx` file--creating a buggy experience.   You can click links to traverse pages, but you can't reload go directly to a page 

### The fix:

Include `.jsx` files in the glob and everything works.  Everything else is already setup to work with this extension.