### PR TITLE
Update copy.js

### DIFF
--- a/tools/copy.js
+++ b/tools/copy.js
@@ -15,4 +15,4 @@ const task = require('./task');
  * Copies static files such as robots.txt, favicon.ico to the
  * output (build) folder.
  */
-module.exports = task('copy', cpy(['static/**/*'], 'build'));
+module.exports = task('copy', cpy(['static/**/*.*'], 'build'));


### PR DESCRIPTION
fixes the following error on `npm run build`:
```js
CpyError: Cannot glob `static/**/*`: Cannot copy from `static/media` to `build/media`: cannot read from `static/media`: EISDIR: illegal operation on a directory, read
    at node_modules/cpy/index.js:65:10
Caused By: Error: EISDIR: illegal operation on a directory, read
    at Error (native)
```